### PR TITLE
Enable additional repos needed by ROS, install updates

### DIFF
--- a/scripts/jetson_setup.sh
+++ b/scripts/jetson_setup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+############## INSTALL UPDATES + USEFUL ADDITIONAL PACKAGES ##############
+sudo apt-get update
+sudo apt-get -y upgrade
+sudo apt-get -y dist-upgrade
+sudo apt-get install -y nano bash-completion git
+
 ############## ADD ROS KINETIC SOURCE ##############
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654

--- a/scripts/jetson_setup.sh
+++ b/scripts/jetson_setup.sh
@@ -35,6 +35,12 @@ sudo mkdir -p /etc/ros
 sudo wget -O /etc/profile.d/clearpath-ros-environment.sh https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/clearpath-ros-environment.sh
 sudo wget -O /etc/ros/setup.bash https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/setup.bash
 
+echo "source /opt/ros/kinetic/setup.bash" >> $HOME/.bashrc
+
+sudo rosdep init
+sudo wget https://raw.githubusercontent.com/clearpathrobotics/public-rosdistro/master/rosdep/50-clearpath.list -O /etc/ros/rosdep/sources.list.d/50-clearpath.list
+rosdep update
+
 ############## UDEV AND CONVENIENCE ##############
 wget -O /home/nvidia/.screenrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/.screenrc
 wget -O /home/nvidia/.vimrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/.vimrc
@@ -65,3 +71,4 @@ rm -rf ds4
 
 ############## BLUETOOTH ##############
 rfkill unblock bluetooth
+

--- a/scripts/jetson_setup.sh
+++ b/scripts/jetson_setup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 ############## INSTALL UPDATES + USEFUL ADDITIONAL PACKAGES ##############
+sudo add-apt-repository universe
+sudo add-apt-repository multiverse
+sudo add-apt-repository restricted
 sudo apt-get update
 sudo apt-get -y upgrade
 sudo apt-get -y dist-upgrade
@@ -22,6 +25,9 @@ sudo apt-get update
 sudo apt-get install -y ros-kinetic-desktop
 sudo apt-get install -y ros-kinetic-husky*
 sudo apt-get install -y ros-kinetic-jackal*
+
+############## APT CLEANUP ##############
+sudo apt-get -y autoremove
 
 ############## SETUP ROS ENVIRONMENT ##############
 sudo mkdir -p /etc/ros


### PR DESCRIPTION
ROS requires the multiverse, universe, and restricted sources to be enabled.  Running the script on a fresh Jetson install with the stock image fails because these are not enabled by default.

For convenience we should also install updates to avoid dependency issues with packages that rely on the latest versions of anything.