### PR TITLE
Add Melodic support for the TX2

### DIFF
--- a/files/41-gamepad.rules
+++ b/files/41-gamepad.rules
@@ -1,0 +1,9 @@
+# Udev rule for the Logitech F710 controller, shipped with some older robots
+KERNEL=="js*", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c21f", SYMLINK="input/f710"
+
+# Udev rule for the PS4 controller currently shipped with most robots
+KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07dc", SYMLINK="input/ps4"
+KERNEL=="js*", ATTRS{idVendor}=="8087", ATTRS{idProduct}=="07da", SYMLINK="input/ps4"
+
+# Alternate Udev rule for the PS4 controller (if it's detected as DualShock 4)
+KERNEL=="js*", ATTRS{idVendor}=="054C", ATTRS{idProduct}=="05C4", SYMLINK="input/ps4"

--- a/scripts/tx2_setup.sh
+++ b/scripts/tx2_setup.sh
@@ -9,7 +9,7 @@ sudo apt-get -y upgrade
 sudo apt-get -y dist-upgrade
 sudo apt-get install -y nano bash-completion git
 
-############## ADD ROS KINETIC SOURCE ##############
+############## ADD ROS MELODIC SOURCE ##############
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
@@ -22,9 +22,9 @@ sudo apt-get install -y apt-transport-https
 sudo apt-get update
 
 ############## ROS ##############
-sudo apt-get install -y ros-kinetic-desktop
-sudo apt-get install -y ros-kinetic-husky*
-sudo apt-get install -y ros-kinetic-jackal*
+sudo apt-get install -y ros-melodic-desktop
+sudo apt-get install -y ros-melodic-husky*
+sudo apt-get install -y ros-melodic-jackal*
 
 ############## APT CLEANUP ##############
 sudo apt-get -y autoremove
@@ -32,43 +32,29 @@ sudo apt-get -y autoremove
 ############## SETUP ROS ENVIRONMENT ##############
 sudo mkdir -p /etc/ros
 
-sudo wget -O /etc/profile.d/clearpath-ros-environment.sh https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/clearpath-ros-environment.sh
-sudo wget -O /etc/ros/setup.bash https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/setup.bash
+sudo wget -O /etc/profile.d/clearpath-ros-environment.sh https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/clearpath-ros-environment.sh
+sudo wget -O /etc/ros/setup.bash https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/setup.bash
 
-echo "source /opt/ros/kinetic/setup.bash" >> $HOME/.bashrc
+echo "source /opt/ros/melodic/setup.bash" >> $HOME/.bashrc
 
 sudo rosdep init
 sudo wget https://raw.githubusercontent.com/clearpathrobotics/public-rosdistro/master/rosdep/50-clearpath.list -O /etc/ros/rosdep/sources.list.d/50-clearpath.list
 rosdep update
 
 ############## UDEV AND CONVENIENCE ##############
-wget -O /home/nvidia/.screenrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/.screenrc
-wget -O /home/nvidia/.vimrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/.vimrc
+wget -O /home/nvidia/.screenrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/.screenrc
+wget -O /home/nvidia/.vimrc https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/.vimrc
 
-sudo wget -O /etc/udev/rules.d/10-microstrain.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/10-microstrain.rules
-sudo wget -O /etc/udev/rules.d/41-clearpath.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/41-clearpath.rules
-sudo wget -O /etc/udev/rules.d/41-hokuyo.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/41-hokuyo.rules
-sudo wget -O /etc/udev/rules.d/52-ftdi.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/52-ftdi.rules
-sudo wget -O /etc/udev/rules.d/60-startech.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/60-startech.rules
+sudo wget -O /etc/udev/rules.d/10-microstrain.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/10-microstrain.rules
+sudo wget -O /etc/udev/rules.d/41-clearpath.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/41-clearpath.rules
+sudo wget -O /etc/udev/rules.d/41-hokuyo.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/41-hokuyo.rules
+sudo wget -O /etc/udev/rules.d/41-gamepad.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/41-gamepad.rules
+sudo wget -O /etc/udev/rules.d/52-ftdi.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/52-ftdi.rules
+sudo wget -O /etc/udev/rules.d/60-startech.rules https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/60-startech.rules
 
 cd ~
-wget https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/HUSKY_SETUP.sh
-wget https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/master/files/JACKAL_SETUP.sh
+wget https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/HUSKY_SETUP.sh
+wget https://raw.githubusercontent.com/clearpathrobotics/jetson_setup/melodic/files/JACKAL_SETUP.sh
 
-############## DS4 ##############
-mkdir ~/ds4
-cd ~/ds4
-git clone https://github.com/clearpathrobotics/ds4drv.git --branch xenial
-sudo apt-get update
-sudo apt-get install -y dpkg-dev debhelper git-buildpackage python-all-dev config-package-dev dkms
-cd ds4drv
-dpkg-buildpackage -uc -us
-cd ..
-sudo dpkg -i python-ds4drv*
-sudo apt-get -f -y install
-cd ~
-rm -rf ds4
-
-############## BLUETOOTH ##############
-rfkill unblock bluetooth
-
+############## BLUEZ ##############
+sudo apt-get install bluez bluez-tools


### PR DESCRIPTION
Update TX2 script to install Melodic, update the Bluetooth & udev portions to use the new method of pairing the PS4 controllers (plus udev rule for the old Logitech F710 controller, for older robots that shipped with that controller).